### PR TITLE
Refactor/#67: 댓글 및 대댓글 스크롤 오류 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/assets/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <title>컨셉비 - 당신의 상상이 현실로!</title>
     <meta
       name="description"

--- a/src/layouts/MobileView.tsx
+++ b/src/layouts/MobileView.tsx
@@ -1,19 +1,25 @@
 import styled from '@emotion/styled';
+import { useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 
+import { MobileViewRefContext } from './contexts/MobileViewContext';
 import Navbar from './Navbar';
 
 const MobileView = () => {
   // TODO: Header 도메인 얽힘 문제 해결 확인 시 사용 예정
   // const isMatchedHeader = hasMatched('/feed', '/feed/:id', '/profile', '/profile/:id', '/profile/:id/more');
 
+  const mobileViewRef = useRef<HTMLDivElement | null>(null);
+
   return (
-    <Container>
-      <Wrapper id="main">
-        <Outlet />
-      </Wrapper>
-      <Navbar />
-    </Container>
+    <MobileViewRefContext.Provider value={{ mobileViewRef }}>
+      <Container>
+        <Wrapper ref={mobileViewRef}>
+          <Outlet />
+        </Wrapper>
+        <Navbar />
+      </Container>
+    </MobileViewRefContext.Provider>
   );
 };
 

--- a/src/layouts/MobileView.tsx
+++ b/src/layouts/MobileView.tsx
@@ -9,7 +9,7 @@ const MobileView = () => {
 
   return (
     <Container>
-      <Wrapper>
+      <Wrapper id="main">
         <Outlet />
       </Wrapper>
       <Navbar />

--- a/src/layouts/contexts/MobileViewContext.tsx
+++ b/src/layouts/contexts/MobileViewContext.tsx
@@ -1,0 +1,23 @@
+import { MutableRefObject, createContext, useContext } from 'react';
+
+interface MobileViewMainContextProps {
+  mobileViewRef: MutableRefObject<HTMLDivElement | null>;
+}
+
+export const MobileViewRefContext = createContext<MobileViewMainContextProps | null>(null);
+
+const useMobileViewContext = () => {
+  const context = useContext(MobileViewRefContext);
+  if (!context) {
+    throw new Error('MobileView 컴포넌트 내부에서만 사용 가능합니다.');
+  }
+
+  return context;
+};
+
+export const useMobileViewRefContext = () => {
+  const context = useMobileViewContext();
+  const { mobileViewRef } = context;
+
+  return mobileViewRef;
+};

--- a/src/pages/FeedDetail/contexts/CommentFocusContext.tsx
+++ b/src/pages/FeedDetail/contexts/CommentFocusContext.tsx
@@ -3,8 +3,8 @@ import { useContext, useState, createContext, MutableRefObject, useRef } from 'r
 type CommentFocusContextType = {
   isFocusComment: boolean;
   openCommentTextarea: () => void;
-  focusRecommentTextarea: () => void;
   closeCommentTextarea: () => void;
+  focusRecommentTextarea: () => void;
   initRecommentTextarea: () => void;
   focusEditCommentTextarea: () => void;
   initEditCommentTextarea: () => void;
@@ -17,13 +17,26 @@ type Props = {
   children: React.ReactNode;
 };
 
+type FocusTextareaRefProps = {
+  textareaRef: MutableRefObject<HTMLTextAreaElement | null>;
+  isInComment: boolean;
+};
+
+const COMMENT_ADJUST_DIFF = 58;
+const RECOMMENT_ADJUST_DIFF = 108;
+
 const CommentFocusContext = createContext<CommentFocusContextType | null>(null);
 
-const focusTextareaRef = (textareaRef: MutableRefObject<HTMLTextAreaElement | null>) => {
+const focusTextareaRef = ({ textareaRef, isInComment }: FocusTextareaRefProps) => {
   if (!textareaRef.current) return;
 
-  textareaRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
   textareaRef.current.focus();
+
+  const root = document.getElementById('main') as HTMLDivElement;
+  const textareaRect = textareaRef.current.getBoundingClientRect();
+  const difference = isInComment ? RECOMMENT_ADJUST_DIFF : COMMENT_ADJUST_DIFF;
+
+  root.scroll({ top: root.scrollTop + textareaRect.top - difference, behavior: 'smooth' });
 };
 
 const initTextareaRef = (textareaRef: MutableRefObject<HTMLTextAreaElement | null>) => {
@@ -37,7 +50,7 @@ export const CommentFocusProvider = ({ children }: Props) => {
   const editCommentTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const openCommentTextarea = () => {
-    focusTextareaRef(commentTextareaRef);
+    focusTextareaRef({ textareaRef: commentTextareaRef, isInComment: false });
 
     setIsFocusComment(true);
   };
@@ -47,7 +60,7 @@ export const CommentFocusProvider = ({ children }: Props) => {
   };
 
   const focusRecommentTextarea = () => {
-    focusTextareaRef(recommentTextareaRef);
+    focusTextareaRef({ textareaRef: recommentTextareaRef, isInComment: true });
   };
 
   const initRecommentTextarea = () => {
@@ -55,7 +68,7 @@ export const CommentFocusProvider = ({ children }: Props) => {
   };
 
   const focusEditCommentTextarea = () => {
-    focusTextareaRef(editCommentTextareaRef);
+    focusTextareaRef({ textareaRef: editCommentTextareaRef, isInComment: true });
   };
 
   const initEditCommentTextarea = () => {
@@ -67,8 +80,8 @@ export const CommentFocusProvider = ({ children }: Props) => {
       value={{
         isFocusComment,
         openCommentTextarea,
-        focusRecommentTextarea,
         closeCommentTextarea,
+        focusRecommentTextarea,
         initRecommentTextarea,
         focusEditCommentTextarea,
         initEditCommentTextarea,

--- a/src/pages/FeedDetail/contexts/CommentFocusContext.tsx
+++ b/src/pages/FeedDetail/contexts/CommentFocusContext.tsx
@@ -36,10 +36,10 @@ const focusTextareaRef = ({ textareaRef, mobileViewRef, isInComment }: FocusText
   textareaRef.current.focus();
 
   const textareaRect = textareaRef.current.getBoundingClientRect();
+  // 댓글 / 대댓글, (대)댓글수정 입력창의 위치에 영향을 주는 요소가 서로 달라 위치 조정값 분기처리
   const difference = isInComment ? RECOMMENT_DIFF : COMMENT_DIFF;
 
-  console.log(mobileViewRef.current.scrollTop + textareaRect.top - difference);
-
+  // MobileView 컴포넌트의 스크롤 Top(가장 상단)을 유저가 선택한 (대)댓글 입력창 위치의 절대값 - 위치 조정값으로 이동
   mobileViewRef.current.scroll({
     top: mobileViewRef.current.scrollTop + textareaRect.top - difference,
     behavior: 'smooth',

--- a/src/pages/FeedDetail/contexts/CommentFocusContext.tsx
+++ b/src/pages/FeedDetail/contexts/CommentFocusContext.tsx
@@ -1,5 +1,7 @@
 import { useContext, useState, createContext, MutableRefObject, useRef } from 'react';
 
+import { useMobileViewRefContext } from '../../../layouts/contexts/MobileViewContext';
+
 type CommentFocusContextType = {
   isFocusComment: boolean;
   openCommentTextarea: () => void;
@@ -19,6 +21,7 @@ type Props = {
 
 type FocusTextareaRefProps = {
   textareaRef: MutableRefObject<HTMLTextAreaElement | null>;
+  mobileViewRef: MutableRefObject<HTMLDivElement | null>;
   isInComment: boolean;
 };
 
@@ -27,16 +30,18 @@ const RECOMMENT_ADJUST_DIFF = 108;
 
 const CommentFocusContext = createContext<CommentFocusContextType | null>(null);
 
-const focusTextareaRef = ({ textareaRef, isInComment }: FocusTextareaRefProps) => {
-  if (!textareaRef.current) return;
+const focusTextareaRef = ({ textareaRef, mobileViewRef, isInComment }: FocusTextareaRefProps) => {
+  if (!textareaRef.current || !mobileViewRef.current) return;
 
   textareaRef.current.focus();
 
-  const root = document.getElementById('main') as HTMLDivElement;
   const textareaRect = textareaRef.current.getBoundingClientRect();
   const difference = isInComment ? RECOMMENT_ADJUST_DIFF : COMMENT_ADJUST_DIFF;
 
-  root.scroll({ top: root.scrollTop + textareaRect.top - difference, behavior: 'smooth' });
+  mobileViewRef.current.scroll({
+    top: mobileViewRef.current.scrollTop + textareaRect.top - difference,
+    behavior: 'smooth',
+  });
 };
 
 const initTextareaRef = (textareaRef: MutableRefObject<HTMLTextAreaElement | null>) => {
@@ -44,13 +49,14 @@ const initTextareaRef = (textareaRef: MutableRefObject<HTMLTextAreaElement | nul
 };
 
 export const CommentFocusProvider = ({ children }: Props) => {
+  const mobileViewRef = useMobileViewRefContext();
   const [isFocusComment, setIsFocusComment] = useState<boolean>(false);
   const commentTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const recommentTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const editCommentTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const openCommentTextarea = () => {
-    focusTextareaRef({ textareaRef: commentTextareaRef, isInComment: false });
+    focusTextareaRef({ textareaRef: commentTextareaRef, mobileViewRef, isInComment: false });
 
     setIsFocusComment(true);
   };
@@ -60,7 +66,7 @@ export const CommentFocusProvider = ({ children }: Props) => {
   };
 
   const focusRecommentTextarea = () => {
-    focusTextareaRef({ textareaRef: recommentTextareaRef, isInComment: true });
+    focusTextareaRef({ textareaRef: recommentTextareaRef, mobileViewRef, isInComment: true });
   };
 
   const initRecommentTextarea = () => {
@@ -68,7 +74,7 @@ export const CommentFocusProvider = ({ children }: Props) => {
   };
 
   const focusEditCommentTextarea = () => {
-    focusTextareaRef({ textareaRef: editCommentTextareaRef, isInComment: true });
+    focusTextareaRef({ textareaRef: editCommentTextareaRef, mobileViewRef, isInComment: true });
   };
 
   const initEditCommentTextarea = () => {

--- a/src/pages/FeedDetail/contexts/CommentFocusContext.tsx
+++ b/src/pages/FeedDetail/contexts/CommentFocusContext.tsx
@@ -25,8 +25,8 @@ type FocusTextareaRefProps = {
   isInComment: boolean;
 };
 
-const COMMENT_ADJUST_DIFF = 58;
-const RECOMMENT_ADJUST_DIFF = 108;
+const COMMENT_DIFF = 58;
+const RECOMMENT_DIFF = 108;
 
 const CommentFocusContext = createContext<CommentFocusContextType | null>(null);
 
@@ -36,7 +36,9 @@ const focusTextareaRef = ({ textareaRef, mobileViewRef, isInComment }: FocusText
   textareaRef.current.focus();
 
   const textareaRect = textareaRef.current.getBoundingClientRect();
-  const difference = isInComment ? RECOMMENT_ADJUST_DIFF : COMMENT_ADJUST_DIFF;
+  const difference = isInComment ? RECOMMENT_DIFF : COMMENT_DIFF;
+
+  console.log(mobileViewRef.current.scrollTop + textareaRect.top - difference);
 
   mobileViewRef.current.scroll({
     top: mobileViewRef.current.scrollTop + textareaRect.top - difference,


### PR DESCRIPTION
## 📄 Summary

close #67

> 댓글 및 대댓글 입력을 위해 입력창 클릭 시 화면이 확대되면서 스크롤이 이상하게 동작하는 오류를 해결합니다.

기존에는 ScrollIntoView 메서드를 활용하여 댓글 및 대댓글 입력창 클릭 시 포커싱을 진행하였지만, Header 높이 값 제외와 같은 세세한 스크롤 조작이 불가했습니다. 따라서 요소의 절대위치와 Header 높이 값 등 차이값(Difference)을 직접 계산하여 스크롤 위치를 조정할 수 있도록 변경하였습니다.

따라서 스크롤이 생기는 영역이 MobileView 컴포넌트이고 이를 조정하기 위해 MobileView의 Wrapper Ref를 필요로 하여 MobileViewContext를 생성하였습니다. 이 컨텍스트는 추후에 페이지간 스크롤 위치 초기화 등에도 사용할 것 같습니다.

참고로 window.scroll로 스크롤 위치를 조작할 수 없습니다. MobileView Wrapper가 100dvh로 지정되어 window의 스크롤이 아닌 MoblieView 내부의 스크롤로 동작하여 그렇습니다. 아래는 리팩토링 비교 영상입니다. 

### PC 환경 (좌: 리팩 전, 우: 리팩 후(현 PR))
![Mar-21-2024 04-25-41](https://github.com/ConceptBe/conceptbe-frontend/assets/89172499/6a0b550e-c937-4df3-8704-38c8f6500126)

### Mobile 가상 키보드 환경 (좌: 리팩 전, 우: 리팩 후(현 PR))
#### 좌측의 경우 스크롤 위치를 상세하게 조절할 수 없어 댓글 입력창이 살짝 가려집니다. 또한 smooth 이벤트가 생략되는 경우도 간헐적으로 있습니다.

![Mar-21-2024 04-27-12](https://github.com/ConceptBe/conceptbe-frontend/assets/89172499/ee1cd454-a130-417c-8f14-347711e996bb)

## 🙋🏻 More

> index.html maximum-scale=1.0 을 설정함으로써 기존의 input, textarea 포커스 시 화면이 확대되는 문제도 같이 해결합니다.

화면 확대 문제가 정상적으로 해결되었는지 확인은 배포 이후에만 가능하여 로컬 환경에서 테스트가 제한적입니다.

## 📝 Reference

https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone