### PR TITLE
Hotfix: 댓글 및 대댓글 하단 공백 오류 수정

### DIFF
--- a/src/pages/FeedDetail/contexts/CommentFocusContext.tsx
+++ b/src/pages/FeedDetail/contexts/CommentFocusContext.tsx
@@ -1,7 +1,5 @@
 import { useContext, useState, createContext, MutableRefObject, useRef, ReactNode } from 'react';
 
-import { useMobileViewRefContext } from '../../../layouts/contexts/MobileViewContext';
-
 interface CommentFocusContextType {
   isFocusComment: boolean;
   openCommentTextarea: () => void;
@@ -19,29 +17,12 @@ interface Props {
   children: ReactNode;
 }
 
-interface FocusTextareaRefProps {
-  textareaRef: MutableRefObject<HTMLTextAreaElement | null>;
-  mobileViewRef: MutableRefObject<HTMLElement | null>;
-}
-
 const CommentFocusContext = createContext<CommentFocusContextType | null>(null);
-const RATIO = window.innerHeight / window.innerWidth;
 
-const focusTextareaRef = ({ textareaRef, mobileViewRef }: FocusTextareaRefProps) => {
+const focusTextareaRef = (textareaRef: MutableRefObject<HTMLTextAreaElement | null>) => {
   if (!textareaRef.current) return;
 
   textareaRef.current.focus();
-
-  if (!mobileViewRef.current || !window.visualViewport) return;
-
-  const textareaRect = textareaRef.current.getBoundingClientRect();
-  const mobileViewHeight = mobileViewRef.current.getBoundingClientRect().height;
-  const currentRatioDiff = window.innerHeight / window.innerWidth - RATIO;
-  const keyboardHeight = window.innerHeight * currentRatioDiff;
-
-  if (currentRatioDiff > 0 && mobileViewHeight - textareaRect.y < keyboardHeight) {
-    textareaRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
-  }
 };
 
 const initTextareaRef = (textareaRef: MutableRefObject<HTMLTextAreaElement | null>) => {
@@ -49,14 +30,13 @@ const initTextareaRef = (textareaRef: MutableRefObject<HTMLTextAreaElement | nul
 };
 
 export const CommentFocusProvider = ({ children }: Props) => {
-  const mobileViewRef = useMobileViewRefContext();
   const [isFocusComment, setIsFocusComment] = useState<boolean>(false);
   const commentTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const recommentTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const editCommentTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const openCommentTextarea = () => {
-    focusTextareaRef({ textareaRef: commentTextareaRef, mobileViewRef });
+    focusTextareaRef(commentTextareaRef);
 
     setIsFocusComment(true);
   };
@@ -66,7 +46,7 @@ export const CommentFocusProvider = ({ children }: Props) => {
   };
 
   const focusRecommentTextarea = () => {
-    focusTextareaRef({ textareaRef: recommentTextareaRef, mobileViewRef });
+    focusTextareaRef(recommentTextareaRef);
   };
 
   const initRecommentTextarea = () => {
@@ -74,7 +54,7 @@ export const CommentFocusProvider = ({ children }: Props) => {
   };
 
   const focusEditCommentTextarea = () => {
-    focusTextareaRef({ textareaRef: editCommentTextareaRef, mobileViewRef });
+    focusTextareaRef(editCommentTextareaRef);
   };
 
   const initEditCommentTextarea = () => {

--- a/src/pages/FeedDetail/contexts/CommentFocusContext.tsx
+++ b/src/pages/FeedDetail/contexts/CommentFocusContext.tsx
@@ -23,6 +23,7 @@ const focusTextareaRef = (textareaRef: MutableRefObject<HTMLTextAreaElement | nu
   if (!textareaRef.current) return;
 
   textareaRef.current.focus();
+  textareaRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
 };
 
 const initTextareaRef = (textareaRef: MutableRefObject<HTMLTextAreaElement | null>) => {


### PR DESCRIPTION
## 📄 Summary

아래 이슈에 대한 핫픽스입니다.

#67

> 결론부터 말씀드리면 전임자분께서 작성한 GlobalCSS의 root, body 에 `min-height: 100vh` 가 문제의 원인이었습니다. 따라서 frontend GlobalCSS, resetCSS를 검토했고 디자인 시스템 역시 검토해서 수정했습니다.
> (관련된 디자인시스템 수정 PR: https://github.com/ConceptBe/conceptbe-design-system/pull/26)

안드로이드와 아이폰이 키보드를 등장시킬 때 동작하는 방식이 다르긴 하지만 innerHeight와 visualViewport.height를 줄이고 늘리는 과정이 있습니다. 그런데 위에서 언급한 min-height 값이 고정됨으로써 키보드가 등장할 때 화면이 줄어들지 않고 찌그러지는 형태가 됩니다. 그리고 키보드가 사라졌을 때 찌그러진 만큼 회복이 되지 않아 하단 공백이 생겼던 것입니다.

따라서 이전 hotfix에서 resize 이벤트 핸들러를 달아 이것저것 시도해봤었는데, 이 또한 필요가없더군요. 갤럭시는 문제가 없지만 [적어도 아이폰은 resize 로직이 필요하다고 하는데](https://velog.io/@gene028/ios-keyboard) 여러번 테스트해본 결과 문제가 없었습니다. 아이폰과 갤럭시가 키보드 높이를 확보하는 방법의 차이점은 [여기에서](https://velog.io/@dongkyun/WebView-aOS-iOS%EC%97%90%EC%84%9C-%ED%82%A4%ED%8C%A8%EB%93%9C-%EC%9C%A0%EB%AC%B4-%ED%8C%8C%EC%95%85%ED%95%98%EA%B8%B0) 확인해보면 좋을 것 같습니다. 추측하건데 저희가 window에서 스크롤을 발생시키지 않고 MobileView에 height: 100dvh를 통해 스크롤을 조작함으로써 얻은 이점이지 않나 생각합니다. 이는 추후 사파리 버전에 따라서 확인해봐야할 수도 있습니다.

추가로 기존에 작성한 스크롤 조정 로직을 `scrollIntoView -> 요소의 절대위치값 y 계산하여 수동 scroll 방식`으로 변경했다가 최종적으로 모두 제거했습니다. 그 이유는 다음과 같습니다.

1. focus() 로직 자체에서 발생하는 스크롤 이벤트가 있어 스크롤 로직이 가끔 씹히는 문제 발생
2. 대댓글 입력창의 경우 대댓글이 얼마나 존재하는지에 따라서 수동으로 계산해야하고 이를 구현하기 위해선 root context의 복잡도가 증가

위 두 단점을 모두 커버하면서 focus() 자체에서 발생하는 스크롤 이벤트를 대체할 정도의 트레이드 오프인지 고민했었고, 결과적으로 기본 focus() 스크롤 이벤트를 선택했습니다. 이 또한 추후 개선 사항이 생긴다면 리팩토링 진행해보겠습니다. 코드는 아래에 백업 해두었습니다.

## 🙋🏻 More

> 추가로 Xcode를 활용한 아이폰 시뮬레이터 디버깅이 야무져서 공유드립니다.

[개발자 메뉴에서 아이폰 사파리를 디버깅하는 방법(Safari Technology Preview)](https://jeongsk.medium.com/%EA%B0%9C%EB%B0%9C%EC%9E%90-%EB%A9%94%EB%89%B4%EC%97%90%EC%84%9C-%EC%95%84%EC%9D%B4%ED%8F%B0-%EC%82%AC%ED%8C%8C%EB%A6%AC%EB%A5%BC-%EB%94%94%EB%B2%84%EA%B9%85%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95-safari-technology-preview-b3354e560344)

예전 방식이 남아있어서 Xcode 시뮬레이터 설치 이후 Safari Technolongy Preview 부분으로 넘어가시길 바랍니다. 외않되 하다가 앞에 작성한 내용은 사파리 버전이 바뀌면서 지원이 중지된 방식이더군요. 용량이 10G 정도 되는 단점말고는 괜찮습니다. 가상키보드도 나오고.

이미 알고 계신 사항일 수도 있습니다. 저는 배포해야만 확인할 수 있을 것이라 생각해서 hotfix 10까지 왔지만 ㅋㅋㅋㅋ 로컬에서도 충분히 테스트할 수 있더군요. `vite --host` 이런 방식으로 실제 아이폰에서 localhost로 접속하는 방법도 해보았는데 좀 까다롭더군요. 제가 해본 결과 접속은 어찌저찌 되는데 router 오류가 생깁니다.

## 📝 BackUp Code (위에서 말씀드린 스크롤 관련 백업 코드입니다. 현재는 사용되지 않습니다.)

#### 가상키보드 resize 로직

```tsx
import styled from '@emotion/styled';
import { MutableRefObject, useEffect, useRef } from 'react';
import { Outlet } from 'react-router-dom';

import { MobileViewRefContext } from './contexts/MobileViewContext';
import Navbar from './Navbar';

const MobileView = () => {
  // TODO: Header 도메인 얽힘 문제 해결 확인 시 사용 예정
  // const isMatchedHeader = hasMatched('/feed', '/feed/:id', '/profile', '/profile/:id', '/profile/:id/more');

  const mobileViewRef = useRef<HTMLElement | null>(null);

  const resizeVisualViewPortResize = (mobileViewRef: MutableRefObject<HTMLElement | null>) => {
    if (!mobileViewRef.current) return;

    const currentVisualViewHeight = window.visualViewport?.height;

    if (!currentVisualViewHeight) return;

    mobileViewRef.current.style.height = `${currentVisualViewHeight}px`;
  };

  useEffect(() => {
    if (!window.visualViewport) return;
    const windowVisualViewPort = window.visualViewport;

    const handleVisualViewPortResize = () => {
      resizeVisualViewPortResize(mobileViewRef);
    };

    windowVisualViewPort.addEventListener('resize', handleVisualViewPortResize);

    return () => {
      windowVisualViewPort.removeEventListener('resize', handleVisualViewPortResize);
    };
  }, [mobileViewRef]);

  return (
    <MobileViewRefContext.Provider value={{ mobileViewRef }}>
      <Wrapper ref={mobileViewRef}>
        <Outlet />
        <Navbar />
      </Wrapper>
    </MobileViewRefContext.Provider>
  );
};

export default MobileView;

const Wrapper = styled.main`
  width: 100%;
  height: 100dvh;
  max-width: 420px;
  max-height: 100%;
  overflow: auto;
  margin: 0 auto;
  -ms-overflow-style: none; /* IE and Edge */
  scrollbar-width: none; /* Firefox */
  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;

  &::-webkit-scrollbar {
    display: none;
  }
`;
```

#### 댓글 열림 시 수동 포커스 로직
```ts
// 댓글 / 대댓글, (대)댓글수정 입력창의 위치에 영향을 주는 요소가 서로 달라 위치 조정값 분리 및 상수화
const COMMENT_DIFF = 58;
const RECOMMENT_DIFF = 108;

const focusTextareaRef = ({ textareaRef, mobileViewRef, isInComment }: FocusTextareaRefProps) => {
  if (!textareaRef.current || !mobileViewRef.current) return;

  textareaRef.current.focus();

  const textareaRect = textareaRef.current.getBoundingClientRect();
  const difference = isInComment ? RECOMMENT_DIFF : COMMENT_DIFF;

  // MobileView 컴포넌트의 스크롤 Top(가장 상단)을 유저가 선택한 (대)댓글 입력창 위치의 절대값 - 위치 조정값으로 이동
  mobileViewRef.current.scroll({
    top: mobileViewRef.current.scrollTop + textareaRect.top - difference,
    behavior: 'smooth',
  });
};

const initTextareaRef = (textareaRef: MutableRefObject<HTMLTextAreaElement | null>) => {
  textareaRef.current = null;
};
```

#### 키보드에 가리는 부분만 자동 포커스 로직
```ts
const focusTextareaRef = ({ textareaRef, mobileViewRef }: FocusTextareaRefProps) => {
  if (!textareaRef.current) return;

  textareaRef.current.focus();

  if (!mobileViewRef.current || !window.visualViewport) return;

  const textareaRect = textareaRef.current.getBoundingClientRect();
  const mobileViewHeight = mobileViewRef.current.getBoundingClientRect().height;
  const currentRatioDiff = window.innerHeight / window.innerWidth - RATIO;
  const keyboardHeight = window.innerHeight * currentRatioDiff;
  
  // currentRatioDiff > 0 면 키보드 올라왔다고 판단, 이후 scrollIntoView로 요소를 화면에 보이도록 자동 포커스
  if (currentRatioDiff > 0 && mobileViewHeight - textareaRect.y < keyboardHeight) {
    textareaRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
  }
};
```
